### PR TITLE
Set options as dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ provide browser executable through this option to your vimrc. Example for google
 ```vimL
 let g:carbon_now_sh_browser = 'google-chrome'
 ```
+
+### Options
+You can set the query string that will be passed to [https://carbon.now.sh](https://carbon.now.sh).
+Example for setting font and line number:
+
+```vimL
+let g:carbon_now_sh_options =
+\ { 'ln': 'true',
+  \ 'fm': 'Source Code Pro' }
+```

--- a/doc/vim-carbon-now-sh.txt
+++ b/doc/vim-carbon-now-sh.txt
@@ -42,7 +42,7 @@ g:carbon_now_sh_options
 		Options passed as query string when opening
 		https://carbon.now.sh. Must not contain `?`.
 
-		Default value: `t=material`
+		Default value: `{}`
 
 g:carbon_now_sh_browser
 		Browser used to open url. If nothing is set, it tries to

--- a/plugin/vim-carbon-now-sh.vim
+++ b/plugin/vim-carbon-now-sh.vim
@@ -12,7 +12,7 @@ command! -range=% CarbonNowSh <line1>,<line2>call s:carbonNowSh()
 function! s:carbonNowSh() range
   let l:text = s:urlEncode(s:getVisualSelection())
   let l:browser = s:getBrowser()
-  let l:options = s:getOptions()
+  let l:options = type(g:carbon_now_sh_options) == v:t_dict ? s:getOptions() : g:carbon_now_sh_options
   let l:filetype = &filetype
 
   call system(l:browser.escape(' https://carbon.now.sh/?'.l:options.'&l='.l:filetype.'&code='.l:text, '?&%'))


### PR DESCRIPTION
1. Currently,  setting `options` to `'bg=rgba(255,255,255,1)'` won't work (at least when `browser='xdg-open'`) unless we  either escape it (`'bg=rgba\(255,255,255,1\)'`) or urlencode it (`'bg=rgba%28255%2C255%2C255%2C1%29'`). Maybe a more intuitive way of using `options` is to set it as dictionariy.

2. As for the modification in `s:urlEncode()`, the issue of `%` in code seems to be fixed in https://github.com/dawnlabs/carbon/commit/4a875194098a149348d0c9214b03264b8a48d99d, so there's no need to urlencode twice(?).