### PR TITLE
Fix bug

### DIFF
--- a/plugin/vim-carbon-now-sh.vim
+++ b/plugin/vim-carbon-now-sh.vim
@@ -16,11 +16,11 @@ function! s:carbonNowSh() range
   let l:filetype = &filetype
   let l:url = 'https://carbon.now.sh/?l=' .. l:filetype .. '&code=' .. l:text .. '&' .. l:options
 
-  if has('win32') && l:browser ==? 'start' && &shell ==? 'cmd.exe'
-    return system(l:browser.' "" "'.l:url.'"')
+  if has('win32') && l:browser ==? 'start' && &shell =~? '\<cmd\.exe$'
+    return system(l:browser .. ' "" "' .. l:url .. '"')
   endif
 
-  call system(l:browser.escape(' '.l:url, '?&%'))
+  call system(l:browser .. escape(' ' .. l:url, '?&%'))
 endfunction
 
 function! s:getBrowser() "{{{
@@ -55,7 +55,7 @@ function! s:getOptions() "{{{
   let l:options = g:carbon_now_sh_options
   let l:result = ''
   for l:key in keys(l:options)
-    let l:result = l:result.'&'.s:urlEncode(l:key).'='.s:urlEncode(l:options[key])
+    let l:result = l:result .. '&' .. s:urlEncode(l:key) .. '=' .. s:urlEncode(l:options[key])
   endfor
   return l:result[1:]
 endfunction "}}}
@@ -70,11 +70,11 @@ function! s:urlEncode(string) "{{{
       while l:i < strlen(l:character)
         let l:byte = strpart(l:character, l:i, 1)
         let l:decimal = char2nr(l:byte)
-        let l:result = l:result.'%'.printf('%02x', l:decimal)
+        let l:result = l:result .. '%' .. printf('%02x', l:decimal)
         let l:i += 1
       endwhile
     else
-      let l:result = l:result.l:character
+      let l:result = l:result .. l:character
     endif
   endfor
 

--- a/plugin/vim-carbon-now-sh.vim
+++ b/plugin/vim-carbon-now-sh.vim
@@ -4,7 +4,7 @@ endif
 
 let g:carbon_now_sh_loaded = 1
 
-let g:carbon_now_sh_options = get(g:, 'carbon_now_sh_options', '{}')
+let g:carbon_now_sh_options = get(g:, 'carbon_now_sh_options', {})
 let g:carbon_now_sh_browser = get(g:, 'carbon_now_sh_browser', '')
 
 command! -range=% CarbonNowSh <line1>,<line2>call s:carbonNowSh()
@@ -14,7 +14,7 @@ function! s:carbonNowSh() range
   let l:browser = s:getBrowser()
   let l:options = type(g:carbon_now_sh_options) == v:t_dict ? s:getOptions() : g:carbon_now_sh_options
   let l:filetype = &filetype
-  let l:url = 'https://carbon.now.sh/?'.l:options.'&l='.l:filetype.'&code='.l:text
+  let l:url = 'https://carbon.now.sh/?l=' .. l:filetype .. '&code=' .. l:text .. '&' .. l:options
 
   if has('win32') && l:browser ==? 'start' && &shell ==? 'cmd.exe'
     return system(l:browser.' "" "'.l:url.'"')
@@ -57,7 +57,7 @@ function! s:getOptions() "{{{
   for l:key in keys(l:options)
     let l:result = l:result.'&'.s:urlEncode(l:key).'='.s:urlEncode(l:options[key])
   endfor
-  return l:result
+  return l:result[1:]
 endfunction "}}}
 
 function! s:urlEncode(string) "{{{


### PR DESCRIPTION
* If options is not set, query string contains `{}`. So always fail to create carbon image.
* Better to use `..` instead of `.` for concat strings.
* Check `\<cmd\.exe$` for Windows shell since &shell may be full-path.