### PR TITLE
Accept alternate base URL (eg. to a local carbon.now instance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ You can also map it to something and use it after selection:
 vnoremap <F5> :CarbonNowSh<CR>
 ```
 
+### Alternate Endpoint
+To send your code snippets to a local instance of carbon.now instead of the public, shared site
+(e.g. if you're doing private development, your code is internal, etc.), pass in an alternate
+base URL via your Vim config:
+
+```vimL
+let g:carbon_now_sh_base_url = 'http://localhost:3000'
+```
+
 ### Browser
 Plugin will try it's best to use your default browser. If it fails, or you want to customize it,
 provide browser executable through this option to your vimrc. Example for google-chrome:

--- a/doc/vim-carbon-now-sh.txt
+++ b/doc/vim-carbon-now-sh.txt
@@ -44,6 +44,12 @@ g:carbon_now_sh_options
 
 		Default value: `{}`
 
+g:carbon_now_sh_base_url
+		Protocol, host name, and port for the carbon.now.sh 
+		instance to send code snippets to.  Note: no trailing slash.
+
+		Default value: 'https://carbon.now.sh'
+
 g:carbon_now_sh_browser
 		Browser used to open url. If nothing is set, it tries to
 		detect default browser by operating system.

--- a/plugin/vim-carbon-now-sh.vim
+++ b/plugin/vim-carbon-now-sh.vim
@@ -6,6 +6,7 @@ let g:carbon_now_sh_loaded = 1
 
 let g:carbon_now_sh_options = get(g:, 'carbon_now_sh_options', {})
 let g:carbon_now_sh_browser = get(g:, 'carbon_now_sh_browser', '')
+let g:carbon_now_sh_base_url = get(g:, 'carbon_now_sh_base_url', 'https://carbon.now.sh')
 
 command! -range=% CarbonNowSh <line1>,<line2>call s:carbonNowSh()
 
@@ -14,7 +15,7 @@ function! s:carbonNowSh() range
   let l:browser = s:getBrowser()
   let l:options = type(g:carbon_now_sh_options) == v:t_dict ? s:getOptions() : g:carbon_now_sh_options
   let l:filetype = &filetype
-  let l:url = 'https://carbon.now.sh/?l=' .. l:filetype .. '&code=' .. l:text .. '&' .. l:options
+  let l:url = g:carbon_now_sh_base_url .. '/?l=' .. l:filetype .. '&code=' .. l:text .. '&' .. l:options
 
   if has('win32') && l:browser ==? 'start' && &shell =~? '\<cmd\.exe$'
     return system(l:browser .. ' "" "' .. l:url .. '"')


### PR DESCRIPTION
1. accepts optional base URL param (e.g. for local or private development work)
2. splits URL into base URL and query string params
3. uses the user's base URL if present
4. updates docs to explain new option

_(untested except on macOS Big Sur 11.3.1, MacVim 8.2.2164 (169)_